### PR TITLE
Add links to implementations in other lanugages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ called a *KSUID*. This library serves as its reference implementation.
 go get -u github.com/segmentio/ksuid
 ```
 
+## Implementations for other languages
+
+- Python: [svix-ksuid](https://github.com/svixhq/python-ksuid/)
+- Ruby: [ksuid-ruby](https://github.com/michaelherold/ksuid-ruby)
+- Java: [ksuid](https://github.com/ksuid/ksuid)
+- Rust: [rksuid](https://github.com/nharring/rksuid)
+- dotNet: [Ksuid.Net](https://github.com/JoyMoe/Ksuid.Net)
+
 ## What is a KSUID?
 
 KSUID is for K-Sortable Unique IDentifier. It is a kind of globally


### PR DESCRIPTION
The Go library is the reference implementation, though not everyone uses Go.
That's why it's useful to link to other implementations so people can use KSUID
in the language of their choice.